### PR TITLE
bug_71715 failed to load frozen column data after scrolling left to right

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -800,10 +800,10 @@ if (typeof Slick === "undefined") {
                         });
                     }
                 });
-                
+
             $headerRowL.empty();
             $headerRowR.empty();
-            
+
             for (var i = 0; i < columns.length; i++) {
                 var m = columns[i];
 
@@ -1944,7 +1944,7 @@ if (typeof Slick === "undefined") {
                         appendCellHtml(stringArrayL, row, i, colspan, d);
                     }
                 } else if (( options.frozenColumn > -1 ) && ( i <= options.frozenColumn )) {
-                    appendCellHtml(stringArrayL, row, i, colspan);
+                    appendCellHtml(stringArrayL, row, i, colspan, d);
                 }
 
                 if (colspan > 1) {


### PR DESCRIPTION
Looks like the logic was a little wonkie, the original writers of this functionality did not take into account the number of columns that could be added to the grid. When rendering frozen columns outside the scope of the normal rendered view-port the data was not being passed in while rendering. I fixed this by passing in the data during rendering.
